### PR TITLE
Multiple bug fixes

### DIFF
--- a/smpp/libsmpp/smpp_bearerbox.c
+++ b/smpp/libsmpp/smpp_bearerbox.c
@@ -293,7 +293,7 @@ void smpp_bearerbox_routing_done(void *context, SMPPRouteStatus *smpp_route_stat
             info(0, "SMPP[%s] Successfully routed message for %s", octstr_get_cstr(smpp_esme->system_id), octstr_get_cstr(smpp_bearerbox_msg->msg->sms.receiver));
             queued_outbound_pdus = smpp_pdu_msg_to_pdu(smpp_esme, smpp_bearerbox_msg->msg);
 
-            while ((pdu = gwlist_consume(queued_outbound_pdus)) != NULL) {
+            while ((queued_outbound_pdus != NULL) && (pdu = gwlist_consume(queued_outbound_pdus)) != NULL) {
                 smpp_queued_deliver_pdu = smpp_queued_pdu_create();
                 smpp_queued_deliver_pdu->pdu = pdu;
                 smpp_queued_deliver_pdu->system_id = octstr_duplicate(smpp_esme->system_id);

--- a/smpp/libsmpp/smpp_esme.c
+++ b/smpp/libsmpp/smpp_esme.c
@@ -291,6 +291,9 @@ List *smpp_esme_global_get_queued(SMPPServer *smpp_server) {
                 msg_queue = smpp_database_get_stored(smpp_server, report_mo, smpp_esme->system_id, limit);
                 while((smpp_database_msg = gwlist_consume(msg_queue)) != NULL) {
                     pdus = smpp_pdu_msg_to_pdu(smpp_esme, smpp_database_msg->msg);
+                    if(pdus == NULL) {
+                        continue;
+                    }
                     while((pdu = gwlist_consume(pdus)) != NULL) {
                         smpp_queued_pdu = smpp_queued_pdu_create();
                         smpp_queued_pdu->pdu = pdu;

--- a/smpp/libsmpp/smpp_pdu_util.c
+++ b/smpp/libsmpp/smpp_pdu_util.c
@@ -480,7 +480,10 @@ List *smpp_pdu_msg_to_pdu(SMPPEsme *smpp_esme, Msg *msg) {
                 pdu2->u.deliver_sm.message_state = dlr_state;
                 dict_destroy(pdu2->u.deliver_sm.tlv);
                 pdu2->u.deliver_sm.tlv = meta_data_get_values(msg->sms.meta_data, "smpp");
-                pdu2->u.deliver_sm.network_error_code = octstr_duplicate(dict_get(metadata, octstr_imm("network_error_code")));
+                if(metadata != NULL) {
+                    pdu2->u.deliver_sm.network_error_code = octstr_duplicate(
+                            dict_get(metadata, octstr_imm("network_error_code")));
+                }
             }
             pdu2->u.deliver_sm.short_message = octstr_format("id:%S sub:001 dlvrd:%S submit date:%s done date:%s stat:%S err:%s text:%S", msgid2, dlvrd, submit_date_c_str, done_date_c_str, dlr_status, err, tmp_str);
             pdu2->u.deliver_sm.sm_length = octstr_len(pdu2->u.deliver_sm.short_message);

--- a/smpp/libsmpp/smpp_pdu_util.c
+++ b/smpp/libsmpp/smpp_pdu_util.c
@@ -58,7 +58,7 @@
  * 
  * This product includes software developed by the Kannel Group (http://www.kannel.org/).
  * 
- */ 
+ */
 
 #include "gwlib/gwlib.h"
 #include "gw/smsc/smpp_pdu.h"
@@ -256,6 +256,8 @@ List *smpp_pdu_msg_to_pdu(SMPPEsme *smpp_esme, Msg *msg) {
     long pos;
     Msg *msg2;
 
+    Dict *metadata;
+
     pdu = smpp_pdu_create(deliver_sm, 0);
 
     pdu->u.deliver_sm.source_addr = octstr_duplicate(msg->sms.sender);
@@ -341,6 +343,8 @@ List *smpp_pdu_msg_to_pdu(SMPPEsme *smpp_esme, Msg *msg) {
 
     /* Is this a delivery report? */
     if (msg->sms.sms_type == report_mo) {
+        metadata = meta_data_get_values(msg->sms.meta_data, "smpp");
+
         pdu->u.deliver_sm.esm_class |= ESM_CLASS_DELIVER_SMSC_DELIVER_ACK;
         dlrtype = msg->sms.dlr_mask;
 
@@ -352,6 +356,7 @@ List *smpp_pdu_msg_to_pdu(SMPPEsme *smpp_esme, Msg *msg) {
             gwlist_destroy(pdulist, NULL);
             octstr_destroy(msgid);
             gwlist_destroy(parts, octstr_destroy_item);
+            dict_destroy(metadata);
             return NULL;
         } else {
             pos = octstr_search_char(msg->sms.dlr_url, '|', 0);
@@ -377,6 +382,7 @@ List *smpp_pdu_msg_to_pdu(SMPPEsme *smpp_esme, Msg *msg) {
                 gwlist_destroy(pdulist, NULL);
                 octstr_destroy(msgid);
                 gwlist_destroy(parts, octstr_destroy_item);
+                dict_destroy(metadata);
                 return NULL;
             }
         }
@@ -408,6 +414,15 @@ List *smpp_pdu_msg_to_pdu(SMPPEsme *smpp_esme, Msg *msg) {
                 dlr_status = octstr_imm("UNDELIV");
                 break;
         }
+
+        if(metadata != NULL) {
+            tmp_str = dict_get(metadata, octstr_imm("dlr_stat"));
+            if(octstr_len(tmp_str) && (octstr_compare(tmp_str, octstr_imm("EXPIRED")) == 0)) {
+                dlr_state = 3;
+                dlr_status = octstr_imm("EXPIRED");
+            }
+        }
+
 
         text = octstr_get_cstr(msg->sms.msgdata);
 
@@ -465,6 +480,7 @@ List *smpp_pdu_msg_to_pdu(SMPPEsme *smpp_esme, Msg *msg) {
                 pdu2->u.deliver_sm.message_state = dlr_state;
                 dict_destroy(pdu2->u.deliver_sm.tlv);
                 pdu2->u.deliver_sm.tlv = meta_data_get_values(msg->sms.meta_data, "smpp");
+                pdu2->u.deliver_sm.network_error_code = octstr_duplicate(dict_get(metadata, octstr_imm("network_error_code")));
             }
             pdu2->u.deliver_sm.short_message = octstr_format("id:%S sub:001 dlvrd:%S submit date:%s done date:%s stat:%S err:%s text:%S", msgid2, dlvrd, submit_date_c_str, done_date_c_str, dlr_status, err, tmp_str);
             pdu2->u.deliver_sm.sm_length = octstr_len(pdu2->u.deliver_sm.short_message);
@@ -481,6 +497,7 @@ List *smpp_pdu_msg_to_pdu(SMPPEsme *smpp_esme, Msg *msg) {
         octstr_destroy(dlr_service);
         octstr_destroy(dlr_submit);
         octstr_destroy(dlr_url);
+        dict_destroy(metadata);
         return pdulist;
     } else {
         pdu->u.deliver_sm.short_message = octstr_duplicate(msg->sms.msgdata);


### PR DESCRIPTION
After some testing of KSMPPD I have found some bugs.

1) When a non-routable DLR or MO is received, KSMPPD would crash - this would happen in the case of moving from SMPPBox/OpenSMPPBox to KSMPPD
2) Expired DLR's are not recognised properly and are generated as generic fails, this patch allows for correct EXPIRED passthrough and message_state