### PR TITLE
Fixed crashing bug on empty MO queued in database

### DIFF
--- a/smpp/ksmppd.c
+++ b/smpp/ksmppd.c
@@ -95,6 +95,8 @@ static void signal_handler(int signum) {
             }
             break;
 
+        case SIGUSR2:
+            warning(0, "SIGUSR2 received, catching and re-opening logs");
         case SIGHUP:
             warning(0, "SIGHUP received, catching and re-opening logs");
             log_reopen();

--- a/smpp/ksmppd.c
+++ b/smpp/ksmppd.c
@@ -97,6 +97,9 @@ static void signal_handler(int signum) {
 
         case SIGUSR2:
             warning(0, "SIGUSR2 received, catching and re-opening logs");
+            log_reopen();
+            alog_reopen();
+            break;
         case SIGHUP:
             warning(0, "SIGHUP received, catching and re-opening logs");
             log_reopen();

--- a/smpp/libsmpp/smpp_bearerbox.h
+++ b/smpp/libsmpp/smpp_bearerbox.h
@@ -82,6 +82,7 @@ extern "C" {
         RWLock *lock;
         SMPPServer *smpp_server;
         Dict *pending_requeues;
+        long requeue_thread_id;
     } SMPPBearerboxState;
 
     typedef struct {

--- a/smpp/libsmpp/smpp_database.c
+++ b/smpp/libsmpp/smpp_database.c
@@ -77,6 +77,7 @@ SMPPDatabaseMsg *smpp_database_msg_create() {
     SMPPDatabaseMsg *smpp_database_msg = gw_malloc(sizeof(SMPPDatabaseMsg));
     smpp_database_msg->global_id = 0;
     smpp_database_msg->msg = NULL;
+    smpp_database_msg->wakeup_thread_id = 0;
     return smpp_database_msg;
 }
 

--- a/smpp/libsmpp/smpp_database.h
+++ b/smpp/libsmpp/smpp_database.h
@@ -72,6 +72,7 @@ extern "C" {
         Msg *msg;
         unsigned long global_id;
         SMPPServer *smpp_server;
+        long wakeup_thread_id;
     } SMPPDatabaseMsg;
     
     

--- a/smpp/libsmpp/smpp_database_mysql.c
+++ b/smpp/libsmpp/smpp_database_mysql.c
@@ -61,6 +61,7 @@
  */ 
 
 #include <ctype.h>
+#include <gw/sms.h>
 #include "gwlib/gwlib.h"
 #include "gwlib/dbpool.h"
 #include "gw/msg.h"
@@ -387,6 +388,10 @@ List *smpp_database_mysql_get_stored(SMPPServer *smpp_server, long sms_type, Oct
 #include "gw/msg-decl.h"
                 default:
                     return NULL;
+            }
+
+            if(msg->sms.msgdata == NULL) {
+                msg->sms.msgdata = octstr_create("");
             }
             
             smpp_database_msg->msg = msg;


### PR DESCRIPTION
If an MO message was received and there was no ESME connected to receive it, this would cause a crashing loop as system unable to deal with NULL MO's out of the database.

Also made use of a thread wakeup to reduce the speed of the requeue in the event that no binds were available.