### PR TITLE
Critical fix - infinite loop on invalid PDU sequence

### DIFF
--- a/smpp/ksmppd.c
+++ b/smpp/ksmppd.c
@@ -133,6 +133,7 @@ static void setup_signal_handlers(void) {
     sigaction(SIGQUIT, &act, NULL);
     sigaction(SIGHUP, &act, NULL);
     sigaction(SIGPIPE, &act, NULL);
+    sigaction(SIGUSR2, &act, NULL);
 //    sigaction(SIGSEGV, &act, NULL);
 }
 

--- a/smpp/libsmpp/smpp_listener.c
+++ b/smpp/libsmpp/smpp_listener.c
@@ -87,6 +87,7 @@ static int smpp_listener_read_pdu(SMPPEsme *smpp_esme, long *len, SMPP_PDU **pdu
         if (*len == -1) {
             error(0, "SMPP[%s:%ld]: Client sent garbage, ignored.",
                   octstr_get_cstr(smpp_esme->system_id), smpp_esme->id);
+            *len = 0;
             return -2;
         } else if (*len == 0) {
             if (conn_eof(conn) || conn_error(conn))


### PR DESCRIPTION
This is an urgent fix - a malicious or invalid client can cause an infinite spin in KSMPPD.