### PR TITLE
[autotools] fix compilation issue in ubuntu 20.04

### DIFF
--- a/smpp/Makefile.am
+++ b/smpp/Makefile.am
@@ -12,4 +12,4 @@ bin_PROGRAMS = ksmppd
 ksmppd_SOURCES =  ksmppd.c
 ksmppd_CPPFLAGS = -I ${top_srcdir}/smpp/libsmpp `gw-config --cflags`
 ksmppd_LDFLAGS = `gw-config --libs` ${libevent_LIBS} -ldl
-ksmppd_LDADD= ${top_srcdir}/smpp/libsmpp.la ${libevent_LIBS}
+ksmppd_LDADD= libsmpp.la ${libevent_LIBS}


### PR DESCRIPTION
this patch is for solving the compilation issue in ubuntu 20.04 using Autotools.

maybe some change happened in Automake which unable to resolve the library dependency.
so this is a quick patch to fix the compilation.